### PR TITLE
global: remove explicit install of db and search

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,55 +25,5 @@ on:
         default: 'Manual trigger'
 
 jobs:
-  Tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-          # You can add/remove combinations e.g. `dev` requirements or `postgresql13` by adding
-          # a new item to the following lists.
-          # You can see the complete list of services and versions that are available at:
-          # https://docker-services-cli.readthedocs.io/en/latest/configuration.html
-          python-version: [3.8, 3.9, "3.10"]
-          requirements-level: [pypi]
-
-    timeout-minutes: 20
-    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.mq-service }})
-
-    env:
-      EXTRAS: tests
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Generate dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools py wheel requirements-builder
-          requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
-
-      - name: Downgrade Setuptools
-        run: |
-          pip install setuptools
-
-      - name: Install dependencies
-        run: |
-          pip install -r .${{matrix.requirements-level}}-${{ matrix.python-version }}-requirements.txt
-          pip install ".[$EXTRAS]"
-          pip freeze
-          docker --version
-          docker-compose --version
-
-      - name: Run tests
-        run: |
-          ./run-tests.sh
+  tests:
+    uses: tu-graz-library/.github/.github/workflows/tests.yml@main

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/invenio_imoox/cli.py
+++ b/invenio_imoox/cli.py
@@ -21,7 +21,7 @@ from .utils import get_identity_from_user_by_email
 
 def get_records_from_imoox(endpoint: str) -> dict:
     """Get the response from imoox."""
-    response = requests.get(endpoint)
+    response = requests.get(endpoint, timeout=10)
     return json.loads(response.text.encode("utf-8"))
 
 

--- a/invenio_imoox/cli.py
+++ b/invenio_imoox/cli.py
@@ -7,7 +7,6 @@
 
 """Click command-line interface for `invenio-imoox` module."""
 
-import json
 import time
 
 import click
@@ -22,7 +21,8 @@ from .utils import get_identity_from_user_by_email
 def get_records_from_imoox(endpoint: str) -> dict:
     """Get the response from imoox."""
     response = requests.get(endpoint, timeout=10)
-    return json.loads(response.text.encode("utf-8"))
+    response.raise_for_status()
+    return response.json()
 
 
 def convert(imoox_records: list) -> dict:

--- a/invenio_imoox/ext.py
+++ b/invenio_imoox/ext.py
@@ -23,7 +23,7 @@ class InvenioIMooX:
         self.init_config(app)
         app.extensions["invenio-imoox"] = self
 
-    def init_config(self, app):  # pylint: disable=no-self-use
+    def init_config(self, app):
         """Initialize configuration."""
         for k in dir(config):
             if k.startswith("INVENIO_IMOOX_"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
 [options.extras_require]
 tests =
     invenio-cache>=1.1.0
+    invenio-search[opensearch2]>=2.1.0
     pytest-invenio>=1.4.3
     pytest-flake8>=1.0.0
     pytest-black>=0.3.0,<0.3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ python_requires = >=3.8
 zip_safe = False
 install_requires =
     click>=7.0.0
-    invenio-records-lom[postgresql,elasticsearch7]>=0.1.0
+    invenio-records-lom>=0.1.0
     requests>=2.0.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ author_email = info@inveniosoftware.org
 platforms = any
 url = https://github.com/tu-graz-library/invenio-imoox
 classifiers =
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Development Status :: 5 - Production/Stable
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,8 @@ tests =
     pytest-invenio>=1.4.3
     pytest-flake8>=1.0.0
     pytest-black>=0.3.0,<0.3.10
-    pytest-isort>=3.0.0
     pytest-pylint>=0.18.0
     pytest-bandit>=0.6.1
-    pytest-pydocstyle>=2.2.0
     Sphinx>=4.4.0
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
 
 [options.extras_require]
 tests =
+    flake8<5.0.0 # necessary to prevent error AttributionError ConfigFileFinder not found
     invenio-cache>=1.1.0
     invenio-search[opensearch2]>=2.1.0
     pytest-invenio>=1.4.3


### PR DESCRIPTION
With this commit it is easier to migrate the invenio-records-lom package
without upgrading every time this one. it is not necessary to state
which db and search tool is used. invenio-records-lom will take care
about this.
